### PR TITLE
Nested Rules (#34)

### DIFF
--- a/src/AST.hpp
+++ b/src/AST.hpp
@@ -62,6 +62,7 @@ enum ASTType {
 	AST_RuleMoveType,
 	AST_RuleName,
 	AST_RuleSublist,
+	AST_RuleSubrules,
 	AST_RuleTarget,
 	AST_RuleType,
 	AST_RuleWithChildDepTarget,

--- a/src/Rule.hpp
+++ b/src/Rule.hpp
@@ -94,6 +94,9 @@ constexpr auto init_flag_excls(rule_flags_t v) {
 
 constexpr auto _flags_excls = make_array<FLAGS_COUNT>(init_flag_excls);
 
+class Rule;
+typedef std::vector<Rule*> RuleVector;
+
 class Rule {
 public:
 	UString name;
@@ -108,6 +111,7 @@ public:
 	KEYWORDS type = K_IGNORE;
 	Set* maplist = nullptr;
 	Set* sublist = nullptr;
+	RuleVector sub_rules;
 
 	mutable ContextList tests;
 	mutable ContextList dep_tests;
@@ -127,7 +131,6 @@ public:
 	static bool cmp_quality(const Rule* a, const Rule* b);
 };
 
-typedef std::vector<Rule*> RuleVector;
 typedef std::map<uint32_t, Rule*> RuleByLineMap;
 typedef std::unordered_map<uint32_t, Rule*> RuleByLineHashMap;
 }

--- a/src/TextualParser.cpp
+++ b/src/TextualParser.cpp
@@ -1534,6 +1534,120 @@ void TextualParser::parseRule(UChar*& p, KEYWORDS key) {
 		}
 	}
 
+	result->lines += SKIPWS(p, '{', ';');
+	if (*p == '{') {
+		++p;
+		bool prev_in_nested_rule = in_nested_rule;
+		Rule* prev_nested_rule = nested_rule;
+		in_nested_rule = true;
+		nested_rule = rule;
+		AST_OPEN(RuleSubrules);
+		result->lines += SKIPWS(p);
+		do {
+			// ADDRELATIONS
+			if (IS_ICASE(p, "ADDRELATIONS", "addrelations")) {
+				parseRule(p, K_ADDRELATIONS); // line 1884
+			}
+			// SETRELATIONS
+			else if (IS_ICASE(p, "SETRELATIONS", "setrelations")) {
+				parseRule(p, K_SETRELATIONS);
+			}
+			// REMRELATIONS
+			else if (IS_ICASE(p, "REMRELATIONS", "remrelations")) {
+				parseRule(p, K_REMRELATIONS);
+			}
+			// ADDRELATION
+			else if (IS_ICASE(p, "ADDRELATION", "addrelation")) {
+				parseRule(p, K_ADDRELATION);
+			}
+			// SETRELATION
+			else if (IS_ICASE(p, "SETRELATION", "setrelation")) {
+				parseRule(p, K_SETRELATION);
+			}
+			// REMRELATION
+			else if (IS_ICASE(p, "REMRELATION", "remrelation")) {
+				parseRule(p, K_REMRELATION);
+			}
+			// SETVARIABLE
+			else if (IS_ICASE(p, "SETVARIABLE", "setvariable")) {
+				parseRule(p, K_SETVARIABLE);
+			}
+			// REMVARIABLE
+			else if (IS_ICASE(p, "REMVARIABLE", "remvariable")) {
+				parseRule(p, K_REMVARIABLE);
+			}
+			// SETPARENT
+			else if (IS_ICASE(p, "SETPARENT", "setparent")) {
+				parseRule(p, K_SETPARENT);
+			}
+			// SETCHILD
+			else if (IS_ICASE(p, "SETCHILD", "setchild")) {
+				parseRule(p, K_SETCHILD);
+			}
+			// RESTORE
+			else if (IS_ICASE(p, "RESTORE", "restore")) {
+				parseRule(p, K_RESTORE);
+			}
+			// IFF
+			else if (IS_ICASE(p, "IFF", "iff")) {
+				parseRule(p, K_IFF);
+			}
+			// MAP
+			else if (IS_ICASE(p, "MAP", "map")) {
+				parseRule(p, K_MAP);
+			}
+			// ADD
+			else if (IS_ICASE(p, "ADD", "add")) {
+				parseRule(p, K_ADD);
+			}
+			// APPEND
+			else if (IS_ICASE(p, "APPEND", "append")) {
+				parseRule(p, K_APPEND);
+			}
+			// SELECT
+			else if (IS_ICASE(p, "SELECT", "select")) {
+				parseRule(p, K_SELECT);
+			}
+			// REMOVE
+			else if (IS_ICASE(p, "REMOVE", "remove")) {
+				parseRule(p, K_REMOVE);
+			}
+			// REPLACE
+			else if (IS_ICASE(p, "REPLACE", "replace")) {
+				parseRule(p, K_REPLACE);
+			}
+			// SUBSTITUTE
+			else if (IS_ICASE(p, "SUBSTITUTE", "substitute")) {
+				parseRule(p, K_SUBSTITUTE);
+			}
+			// COPY
+			else if (IS_ICASE(p, "COPY", "copy")) {
+				parseRule(p, K_COPY);
+			}
+			// UNMAP
+			else if (IS_ICASE(p, "UNMAP", "unmap")) {
+				parseRule(p, K_UNMAP);
+			}
+			// PROTECT
+			else if (IS_ICASE(p, "PROTECT", "protect")) {
+				parseRule(p, K_PROTECT);
+			}
+			// UNPROTECT
+			else if (IS_ICASE(p, "UNPROTECT", "unprotect")) {
+				parseRule(p, K_UNPROTECT);
+			}
+			result->lines += SKIPWS(p, '}', ';');
+			if (*p == ';') {
+				++p;
+				result->lines += SKIPWS(p);
+			}
+		} while (*p != '}');
+		++p;
+		AST_CLOSE(p);
+		nested_rule = prev_nested_rule;
+		in_nested_rule = prev_in_nested_rule;
+	}
+
 	rule->reverseContextualTests();
 	if (only_sets) {
 		result->destroyRule(rule);
@@ -2994,7 +3108,11 @@ void TextualParser::setVerbosity(uint32_t level) {
 }
 
 void TextualParser::addRuleToGrammar(Rule* rule) {
-	if (in_section) {
+	if (in_nested_rule) {
+		rule->section = -4; // TODO: does this need to be defined?
+		nested_rule->sub_rules.push_back(rule);
+	}
+	else if (in_section) {
 		rule->section = SI32(result->sections.size()) - 1;
 		result->addRule(rule);
 	}

--- a/src/TextualParser.hpp
+++ b/src/TextualParser.hpp
@@ -67,10 +67,11 @@ private:
 	uint32_t seen_mapping_prefix = 0;
 	flags_t section_flags;
 	bool option_vislcg_compat = false;
-	bool in_section = false, in_before_sections = true, in_after_sections = false, in_null_section = false;
+	bool in_section = false, in_before_sections = true, in_after_sections = false, in_null_section = false, in_nested_rule = false;
 	bool no_isets = false, no_itmpls = false, strict_wforms = false, strict_bforms = false, strict_second = false, strict_regex = false, strict_icase = false;
 	bool self_no_barrier = false;
 	bool only_sets = false;
+	Rule* nested_rule = nullptr;
 	const char* filename = nullptr;
 
 	typedef std::unordered_map<ContextualTest*, std::pair<size_t, UString>> deferred_t;

--- a/test/T_Subrule/expected.txt
+++ b/test/T_Subrule/expected.txt
@@ -1,0 +1,26 @@
+"<all>"
+	"all" predet sp #1->2
+"<the>"
+	"the" det def sp @det #2->3
+"<things>"
+	"thing" n pl #3->3
+"<.>"
+	"." sent #4->4
+
+"<the>"
+	"the" det def sp @det #1->2
+"<things>"
+	"thing" n pl #2->3
+"<.>"
+	"." sent #3->3
+
+"<all>"
+	"all" predet sp #1->1
+"<the>"
+	"the" det def sp #2->2
+"<pretty>"
+	"pretty" adj #3->3
+"<things>"
+	"thing" n pl #4->4
+"<.>"
+	"." sent #5->5

--- a/test/T_Subrule/grammar.cg3
+++ b/test/T_Subrule/grammar.cg3
@@ -1,0 +1,10 @@
+DELIMITERS = "<.>" ;
+
+LIST @det = @det ;
+
+SECTION
+
+MAP @det (det def) IF (1X (n)) {
+  SETPARENT (*) TO (1 _MARK_) ;
+  SETCHILD (*) TO (-1 (predet)) ;
+} ;

--- a/test/T_Subrule/input.txt
+++ b/test/T_Subrule/input.txt
@@ -1,0 +1,26 @@
+"<all>"
+	"all" predet sp
+"<the>"
+	"the" det def sp
+"<things>"
+	"thing" n pl
+"<.>"
+	"." sent
+
+"<the>"
+	"the" det def sp
+"<things>"
+	"thing" n pl
+"<.>"
+	"." sent
+
+"<all>"
+	"all" predet sp
+"<the>"
+	"the" det def sp
+"<pretty>"
+	"pretty" adj
+"<things>"
+	"thing" n pl
+"<.>"
+	"." sent


### PR DESCRIPTION
This PR adds the option for any rule to be followed by a list of rules in `{}` where the latter rules are only run if the first one matches, and the latter rules also inherit `_TARGET_` and `_MARK_` from the first rule.

```
MAP (@det) (det def) IF (1X (n)) {
  SETPARENT (*) TO (1 _MARK_) ;
  SETCHILD (*) TO (-1 (predet)) ;
} ;
```

Currently such rules are parsed but not applied. I think to finish this all that's really needed is to reorganize `GrammarApplicator::runRulesOnSingleWindow` a bit to separate applying a single rule from the outer action loop.