### PR TITLE
WIP: Compile emscripten with ports of boost/icu/sqlite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if(BIG_ENDIAN)
 	add_definitions(-DBIG_ENDIAN)
 endif()
 
+include(CheckIncludeFileCXX)
 CHECK_INCLUDE_FILE_CXX(filesystem HAS_FS)
 if(HAS_FS)
 	add_definitions(-DHAS_FS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,45 +1,59 @@
 # Threading, for exec-stream
 # There's some weird bug/interaction with recent Apple toolchains and this, so disable for now.
-if(NOT APPLE)
-	find_package(Threads REQUIRED)
+if(EMSCRIPTEN)
+    message(STATUS "Detected EMSCRIPTEN: skipping local library discovery and using Emscripten ports")
+    # Emscripten ports flags for Boost, ICU, SQLite3:
+    set(USE_FLAGS "--use-port=boost_headers --use-port=icu --use-port=sqlite3")
+
+    # Append to CXX flags, exe linker flags, and shared linker flags.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${USE_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${USE_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${USE_FLAGS}")
+
+    # No threading for Emscripten build
+    set(CMAKE_THREAD_LIBS_INIT "")
 else()
-	# See https://trac.macports.org/ticket/71642
-	cmake_policy(SET CMP0167 OLD)
-endif()
-
-# Boost
-find_path(Boost_LOCAL NAMES boost/config.hpp PATHS "../include" NO_DEFAULT_PATH)
-if(Boost_LOCAL)
-	set(BOOST_ROOT "../include")
-	find_package(Boost 1.62.0)
-endif()
-if(NOT Boost_FOUND)
-	unset(BOOST_ROOT)
-	message(STATUS "Did not find Boost locally; trying globally...")
-	message(STATUS "If this doesn't work, run ./get-boost.sh and try again.")
-	find_package(Boost 1.62.0 REQUIRED)
-endif()
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
-
-# ICU
-find_package(ICU 59.0 COMPONENTS i18n io uc data REQUIRED)
-if(ICU_FOUND)
-	include_directories(${ICU_INCLUDE_DIRS})
-	message(STATUS "Found ICU version ${ICU_VERSION}")
-endif()
-link_directories(${ICU_LIBRARY_DIRS})
-
-if(ENABLE_PROFILING)
-	if(VCPKG_TOOLCHAIN)
-		find_path(SQLITE3_INCLUDE_DIRS sqlite3.h REQUIRED)
-		find_library(SQLITE3_LIBRARIES sqlite3 REQUIRED)
+	if(NOT APPLE)
+		find_package(Threads REQUIRED)
 	else()
-		find_package(PkgConfig REQUIRED)
-		pkg_search_module(SQLITE3 REQUIRED sqlite3)
+		# See https://trac.macports.org/ticket/71642
+		cmake_policy(SET CMP0167 OLD)
 	endif()
-	include_directories(${SQLITE3_INCLUDE_DIRS})
-	link_directories(${SQLITE3_LIBRARY_DIRS})
+
+	# Boost
+	find_path(Boost_LOCAL NAMES boost/config.hpp PATHS "../include" NO_DEFAULT_PATH)
+	if(Boost_LOCAL)
+		set(BOOST_ROOT "../include")
+		find_package(Boost 1.62.0)
+	endif()
+	if(NOT Boost_FOUND)
+		unset(BOOST_ROOT)
+		message(STATUS "Did not find Boost locally; trying globally...")
+		message(STATUS "If this doesn't work, run ./get-boost.sh and try again.")
+		find_package(Boost 1.62.0 REQUIRED)
+	endif()
+	include_directories(${Boost_INCLUDE_DIRS})
+	link_directories(${Boost_LIBRARY_DIRS})
+
+	# ICU
+	find_package(ICU 59.0 COMPONENTS i18n io uc data REQUIRED)
+	if(ICU_FOUND)
+		include_directories(${ICU_INCLUDE_DIRS})
+		message(STATUS "Found ICU version ${ICU_VERSION}")
+	endif()
+	link_directories(${ICU_LIBRARY_DIRS})
+
+	if(ENABLE_PROFILING)
+		if(VCPKG_TOOLCHAIN)
+			find_path(SQLITE3_INCLUDE_DIRS sqlite3.h REQUIRED)
+			find_library(SQLITE3_LIBRARIES sqlite3 REQUIRED)
+		else()
+			find_package(PkgConfig REQUIRED)
+			pkg_search_module(SQLITE3 REQUIRED sqlite3)
+		endif()
+		include_directories(${SQLITE3_INCLUDE_DIRS})
+		link_directories(${SQLITE3_LIBRARY_DIRS})
+	endif()
 endif()
 
 macro(cg3_link target)
@@ -50,15 +64,15 @@ macro(cg3_link target)
 			-sEXPORTED_FUNCTIONS=['_cg3_init','_cg3_init','_cg3_cleanup','_cg3_cleanup','_cg3_grammar_load','_cg3_grammar_load_buffer','_cg3_grammar_free','_cg3_applicator_create','_cg3_applicator_setflags','_cg3_applicator_setoption','_cg3_applicator_setoption','_cg3_applicator_setoption','_cg3_applicator_free','_cg3_run_grammar_on_text','_cg3_run_grammar_on_text_fns','_cg3_mwesplitapplicator_create','_cg3_sentence_new','_cg3_sentence_copy','_cg3_sentence_runrules','_cg3_sentence_addcohort','_cg3_sentence_numcohorts','_cg3_sentence_getcohort','_cg3_sentence_free','_cg3_cohort_create','_cg3_cohort_setwordform','_cg3_cohort_getwordform','_cg3_cohort_getid','_cg3_cohort_setdependency','_cg3_cohort_getdependency','_cg3_cohort_addreading','_cg3_cohort_numreadings','_cg3_cohort_getreading','_cg3_cohort_free','_cg3_reading_create','_cg3_reading_addtag','_cg3_reading_numtags','_cg3_reading_gettag','_cg3_reading_numtraces','_cg3_reading_gettrace','_cg3_reading_free','_cg3_subreading_create','_cg3_reading_setsubreading','_cg3_reading_numsubreadings','_cg3_reading_getsubreading','_cg3_subreading_free','_cg3_tag_create_u','_cg3_tag_create_u8','_cg3_tag_create_u16','_cg3_tag_create_u32','_cg3_tag_create_w','_cg3_tag_gettext_u','_cg3_tag_gettext_u8','_cg3_tag_gettext_u16','_cg3_tag_gettext_u32','_cg3_tag_gettext_w','_cg3_cohort_numdelreadings','_cg3_cohort_getdelreading','_cg3_reading_gettrace_ruletype']
 			-sASSERTIONS=1
 			)
+	else()
+		target_link_libraries(${target}
+			${CMAKE_THREAD_LIBS_INIT}
+			${STDFS_LIB}
+			${Boost_LIBRARIES}
+			${ICU_LIBRARIES}
+			${SQLITE3_LIBRARIES}
+			)
 	endif()
-
-	target_link_libraries(${target}
-		${CMAKE_THREAD_LIBS_INIT}
-		${STDFS_LIB}
-		${Boost_LIBRARIES}
-		${ICU_LIBRARIES}
-		${SQLITE3_LIBRARIES}
-		)
 endmacro()
 
 set(LIBCG3_SOURCES


### PR DESCRIPTION
resolves https://github.com/apertium/wasm/issues/2 (and https://github.com/apertium/wasm/issues/1 ?)

This appears to compile fine, and the example in https://github.com/apertium/wasm/blob/main/README.md works correctly.

There are a few warnings about the following that I am not qualified to address.
1) SHARED vs STATIC
2) `main` is defined in the input files, but `_main` is not in `EXPORTED_FUNCTIONS`
3) running limited binaryen optimizations because DWARF info requested (or indirectly required) [-Wlimited-postlink-optimizations]

I did NOT compile the standard OS binaries, so you should check that these edits have not broken those builds.