### PR TITLE
Simpler and more conservative case changes in cg-proc -w

### DIFF
--- a/src/ApertiumApplicator.hpp
+++ b/src/ApertiumApplicator.hpp
@@ -25,7 +25,7 @@
 
 namespace CG3 {
 
-enum ApertiumCasing { Lower, Title, Upper };
+enum ApertiumCasing { Nochange, Title, Upper };
 
 class ApertiumApplicator : public virtual GrammarApplicator {
 public:


### PR DESCRIPTION
Only words with all UPPER (and at least two such) are turned uppercase

Only words with first (and only first) letter upper and at least two characters are turned titlecase

fix https://github.com/GrammarSoft/cg3/issues/165
